### PR TITLE
#21 마이프로필 3개 이상 생성되는 버그 해결

### DIFF
--- a/src/main/java/com/example/aboutme/service/ProfileService/ProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/ProfileService/ProfileServiceImpl.java
@@ -48,7 +48,7 @@ public class ProfileServiceImpl implements ProfileService{
 
         // 최대 생성 개수 초과하는지 확인
         int MAX_PROFILE_SIZE = 3;
-        if(profileRepository.countByMember(member) > MAX_PROFILE_SIZE){
+        if(profileRepository.countByMember(member) >= MAX_PROFILE_SIZE){
             throw new GeneralException(ErrorStatus.PROFILE_SIZE_OVERFLOW);
         }
 

--- a/src/main/java/com/example/aboutme/service/ProfileService/ProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/ProfileService/ProfileServiceImpl.java
@@ -79,8 +79,11 @@ public class ProfileServiceImpl implements ProfileService{
         int serialNumber = generator.nextInt(1000000) % 1000000;
 
         // 중복 확인
-        while(profileRepository.findBySerialNumber(serialNumber).isPresent()){
+        boolean isDuplicated = profileRepository.findBySerialNumber(serialNumber).isPresent();
+        while(isDuplicated){
             serialNumber = generator.nextInt(1000000) % 1000000;
+
+            isDuplicated = profileRepository.findBySerialNumber(serialNumber).isPresent();
         }
 
         return serialNumber;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
#21 

## 📌 개요
- 마이프로필이 최대 4개까지 생성되는 버그가 있었음. 최대 3개까지 생성되도록 수정

## 🔁 변경 사항
- 마이프로필의 시리얼 넘버 중복확인 로직 메소드로 빼보려했는데,
profileRepository.findBySerialNumber(serialNumber).isPresent();
이것 한줄만 메소드로 만들 수 있게 되더라구요. 그래서 차라리 그것보단
클린코드 관련 글 봤을 때 조건에 대해서는 변수 붙여서 확인하는게 유지보수에 좋다는 내용을 봐
isDuplicated라는 변수를 두는게 낫지 않을까 싶어서 그렇게 변경했습니다!

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
