### PR TITLE
#106 내 마이프로필 상대방에게 공유하기

### DIFF
--- a/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_NOT_MATCH_MEMBER_AT_DELETE(HttpStatus.BAD_REQUEST, "PROFILE402", "해당 프로필을 삭제할 수 없습니다"),
     PROFILE_NOT_MATCH_MEMBER_AT_GET(HttpStatus.BAD_REQUEST, "PROFILE406", "해당 프로필을 조회할 수 없습니다"),
     PROFILE_NOT_MATCH_MEMBER_AT_UPDATE(HttpStatus.BAD_REQUEST, "PROFILE407", "해당 프로필을 수정할 수 없습니다"),
+    PROFILE_NOT_MINE(HttpStatus.BAD_REQUEST, "PROFILE408", "공유하려는 프로필이 본인 것이 아닙니다."),
 
     // 마이프로필 이미지 에러
     PROFILE_IMAGE_CANNOT_CHANGE_TO_CHARACTER(HttpStatus.BAD_REQUEST, "IMAGE400", "마이스페이스에서 캐릭터를 설정해야 합니다"),

--- a/src/main/java/com/example/aboutme/app/controller/MemberProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/MemberProfileController.java
@@ -53,4 +53,5 @@ public class MemberProfileController {
         List<MemberProfile> memberProfileList = memberProfileService.filterWithKeyword(memberId, keyword);
         return ApiResponse.onSuccess(MemberProfileConverter.toSearchMemberProfileListDTO(memberProfileList));
     }
+
 }

--- a/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
@@ -44,4 +44,15 @@ public class ProfileRequest {
         @CheckEnumType(enumClass = ProfileImageType.class)
         private String profileImageType;
     }
+
+    @Getter
+    public static class ShareMyProfileDTO{
+
+        @JsonProperty("member_id")
+        private Long memberId;
+
+        @JsonProperty("profile_serial_numbers")
+        @ExistProfilesBySerialNum
+        private List<Integer> profileSerialNumberList;
+    }
 }

--- a/src/main/java/com/example/aboutme/app/dto/ProfileResponse.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileResponse.java
@@ -160,4 +160,13 @@ public class ProfileResponse {
         @JsonProperty("is_default")
         private Boolean isDefault;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ShareProfileDTO{
+        @JsonProperty("member_id")
+        private Long memberId;
+    }
 }

--- a/src/main/java/com/example/aboutme/converter/MemberProfileConverter.java
+++ b/src/main/java/com/example/aboutme/converter/MemberProfileConverter.java
@@ -46,6 +46,16 @@ public class MemberProfileConverter {
                 .favorite(false)
                 .member(member)
                 .profile(profile)
+                .approved(true)
+                .build();
+    }
+
+    public static MemberProfile toMemberProfileNotApproved(Member member, Profile profile){
+        return MemberProfile.builder()
+                .favorite(false)
+                .member(member)
+                .profile(profile)
+                .approved(false)
                 .build();
     }
 

--- a/src/main/java/com/example/aboutme/converter/ProfileConverter.java
+++ b/src/main/java/com/example/aboutme/converter/ProfileConverter.java
@@ -125,4 +125,10 @@ public class ProfileConverter {
                 .isDefault(profile.getIsDefault())
                 .build();
     }
+
+    public static ProfileResponse.ShareProfileDTO toShareMyProfileDTO(Long memberId){
+        return ProfileResponse.ShareProfileDTO.builder()
+                .memberId(memberId)
+                .build();
+    }
 }

--- a/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
+++ b/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
@@ -18,11 +18,9 @@ public class MemberProfile extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false) 
-    private Boolean favorite = false;
+    private Boolean favorite;
 
-    @Column(nullable = false)
-    private Boolean approved = true;
+    private Boolean approved;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
+++ b/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
@@ -13,11 +13,16 @@ import javax.persistence.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberProfile extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Boolean favorite;
+    @Column(nullable = false) 
+    private Boolean favorite = false;
+
+    @Column(nullable = false)
+    private Boolean approved = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
@@ -8,11 +8,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
-    List<MemberProfile> findAllByMember(Member member);
+//    List<MemberProfile> findAllByMember(Member member);
+
+    List<MemberProfile> findAllByMemberAndApprovedIsTrue(Member member);
+
 
 //    MemberProfile findByMemberAndId(Member member, Long memberProfileId);
 
     MemberProfile findByMemberAndProfile(Member member, Profile profile);
     Boolean existsByMemberAndProfile(Member member, Profile profile);
-    List<MemberProfile> findByMemberAndProfileIn(Member member, List<Profile> profiles);
+    List<MemberProfile> findByMemberAndProfileInAndApprovedIsTrue(Member member, List<Profile> profileList);
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
@@ -19,7 +19,9 @@ public interface MemberProfileService {
      * @param memberId 멤버 식별자
      * @param request
      */
-    void addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request);
+    Long addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request);
+
+    void shareMyProfilesToOthers(Long memberId, ProfileRequest.ShareMyProfileDTO request);
 
     List<MemberProfile> filterWithKeyword(Long memberId, String keyword);
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -75,7 +75,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
      * @param request
      */
     @Transactional
-    public void addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request){
+    public Long addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request){
 
         Member member = memberService.findMember(memberId);
 
@@ -83,6 +83,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
         List<Profile> otherProfileList = request.getProfileSerialNumberList().stream()
                 .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
                 .toList();
+
+        Long profileOwnerId = otherProfileList.isEmpty() ? null : otherProfileList.get(0).getMember().getId();
 
         for(Profile otherProfile : otherProfileList){
             // 이미 공유된 프로필일 경우
@@ -102,6 +104,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
         memberProfileList.forEach(memberProfile -> {
             memberProfileRepository.save(memberProfile);
         });
+
+        return profileOwnerId;
     }
 
     /**
@@ -120,5 +124,42 @@ public class MemberProfileServiceImpl implements MemberProfileService {
                 .toList();
 
         return memberProfileRepository.findByMemberAndProfileIn(member, profileList);
+    }
+
+    /**
+     * 내 마이프로필 상대방에게 공유하기
+     * @param memberId 멤버 식별자
+     * @param request
+     */
+    @Transactional
+    public void shareMyProfilesToOthers(Long memberId, ProfileRequest.ShareMyProfileDTO request){
+
+        Member member = memberService.findMember(memberId);
+
+        // 추가하려는 마이프로필 목록 조회
+        List<Profile> otherProfileList = request.getProfileSerialNumberList().stream()
+                .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
+                .toList();
+
+        Member shareTarget = memberService.findMember(request.getMemberId());
+
+        for(Profile otherProfile : otherProfileList){
+            // 공유하려는 프로필이 본인게 아닌 경우
+            if(otherProfile.getMember() != member){
+                throw new GeneralException(ErrorStatus.PROFILE_NOT_MINE);
+            }
+            // 이미 공유된 프로필일 경우
+            if(memberProfileRepository.existsByMemberAndProfile(shareTarget, otherProfile)){
+                throw new GeneralException(ErrorStatus.MEMBER_PROFILE_ALREADY_EXIST);
+            }
+        }
+
+        List<MemberProfile> memberProfileList = otherProfileList.stream()
+                .map(otherProfile -> MemberProfileConverter.toMemberProfileNotApproved(shareTarget, otherProfile))
+                .toList();
+
+        memberProfileList.forEach(memberProfile -> {
+            memberProfileRepository.save(memberProfile);
+        });
     }
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -52,7 +52,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
 
     public List<MemberProfile> getMyProfilesStorage(Long memberId){
         Member member = memberService.findMember(memberId);
-        return memberProfileRepository.findAllByMember(member);
+        return memberProfileRepository.findAllByMemberAndApprovedIsTrue(member);
     }
 
     @Transactional
@@ -123,7 +123,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
                 .map(ProfileFeature::getProfile)
                 .toList();
 
-        return memberProfileRepository.findByMemberAndProfileIn(member, profileList);
+        return memberProfileRepository.findByMemberAndProfileInAndApprovedIsTrue(member, profileList);
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #106 

## 📌 개요
- 마이프로필 공유 기능
- 공유된 마이프로필(MemberProfile)에 승인여부(approved) 칼럼을 추가합니다.
- 본인이 상대방 프로필 추가시 approved = true, 상대방에게 본인 프로필 공유시 approved = false
- 프로필 보관함에서 approved = true인 프로필만 조회/검색되도록 변경

## 🔁 변경 사항
상대방 마이프로필 내 보관함에 추가하기 API 응답 본문 변경
```json
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "member_id": 3
    }
}
```

내 마이프로필 상대방에게 공유하기 API 요청 본문
```json
{
	"member_id": 3
	"profile_serial_numbers": [123456, 987654]
}
```

`200 OK`

```json
{
	"isSuccess": true,
	"code" : 200,
	"message" : "요청이 성공적으로 처리되었습니다."
}
```
`400 Bad Request`

```json
{
    "isSuccess": false,
    "code": "PROFILE408",
    "message": "공유하려는 프로필이 본인 것이 아닙니다."
}
```

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
