### PR TITLE
#107 공유받은 상대방 프로필 저장하기

### DIFF
--- a/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_NOT_MATCH_MEMBER_AT_GET(HttpStatus.BAD_REQUEST, "PROFILE406", "해당 프로필을 조회할 수 없습니다"),
     PROFILE_NOT_MATCH_MEMBER_AT_UPDATE(HttpStatus.BAD_REQUEST, "PROFILE407", "해당 프로필을 수정할 수 없습니다"),
     PROFILE_NOT_MINE(HttpStatus.BAD_REQUEST, "PROFILE408", "공유하려는 프로필이 본인 것이 아닙니다."),
+    PROFILE_ALREADY_SHARED(HttpStatus.BAD_REQUEST, "PROFILE409", "이미 저장된 프로필입니다."),
 
     // 마이프로필 이미지 에러
     PROFILE_IMAGE_CANNOT_CHANGE_TO_CHARACTER(HttpStatus.BAD_REQUEST, "IMAGE400", "마이스페이스에서 캐릭터를 설정해야 합니다"),

--- a/src/main/java/com/example/aboutme/app/controller/ProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/ProfileController.java
@@ -215,4 +215,21 @@ public class ProfileController {
 
         return ApiResponse.onSuccess(ProfileConverter.toSearchProfile(profile));
     }
+
+    /**
+     * [PATCH] /myprofiles/share/approve
+     * 프로필 공유받기
+     *
+     * @param memberId 멤버 식별자
+     * @param profileId 마이프로필 식별자
+     * @return
+     */
+    @PatchMapping("/share/{profile-id}")
+    public ApiResponse<Void> approveProfile(@RequestHeader("member-id") Long memberId,
+                                            @PathVariable("profile-id") @ExistMyProfile Long profileId) {
+
+        memberProfileService.toggleApproved(memberId, profileId);
+
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
@@ -48,8 +48,8 @@ public class ProfileRequest {
     @Getter
     public static class ShareMyProfileDTO{
 
-        @JsonProperty("member_id")
-        private Long memberId;
+        @JsonProperty("target_member_id")
+        private Long targetMemberId;
 
         @JsonProperty("profile_serial_numbers")
         @ExistProfilesBySerialNum

--- a/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
+++ b/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
@@ -30,8 +30,11 @@ public class MemberProfile extends BaseEntity {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
-    // 즐겨찾기 토글 메서드
     public void toggleFavorite() {
         this.favorite = !this.favorite;
+    }
+
+    public void toggleApproved() {
+        this.approved = !this.approved;
     }
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
@@ -11,6 +11,8 @@ import java.util.List;
 public interface MemberProfileService {
     Boolean toggleFavorite(Long memberId, Long profileId);
 
+    Boolean toggleApproved(Long memberId, Long profileId);
+
     List<MemberProfile> getMyProfilesStorage(Long memberId);
 
     MemberProfile deleteMemberProfile(Long memberId, Long profileId);

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -162,4 +162,31 @@ public class MemberProfileServiceImpl implements MemberProfileService {
             memberProfileRepository.save(memberProfile);
         });
     }
+
+
+    /**
+     * 프로필 공유받기
+     * @param memberId 멤버 식별자
+     * @param profileId 마이프로필 식별자
+     */
+    @Transactional
+    public Boolean toggleApproved(Long memberId, Long profileId) {
+
+        Member member = memberService.findMember(memberId);
+
+        Profile profile = profileRepository.findById(profileId).get();
+
+        MemberProfile memberProfile = memberProfileRepository.findByMemberAndProfile(member, profile);
+        if (memberProfile == null) {
+            throw new GeneralException(ErrorStatus.MEMBER_PROFILE_NOT_FOUND);
+        }
+
+        if (memberProfile.getApproved()) {
+            throw new GeneralException(ErrorStatus.PROFILE_ALREADY_SHARED);
+        }
+
+        memberProfile.toggleApproved();
+
+        return memberProfile.getApproved();
+    }
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -141,7 +141,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
                 .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
                 .toList();
 
-        Member shareTarget = memberService.findMember(request.getMemberId());
+        Member shareTarget = memberService.findMember(request.getTargetMemberId());
 
         for(Profile otherProfile : otherProfileList){
             // 공유하려는 프로필이 본인게 아닌 경우


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #109 

## 📌 개요
- 아래 이미지의 저장 버튼 클릭시 사용할 API입니다. <img width="557" alt="스크린샷 2024-02-12 오후 8 15 21" src="https://github.com/UMC-AboutMe/AboutMe-BE/assets/122276414/df2ab703-2774-4233-b28d-cf11a9e3a693">

- MemberProfile의 approved 필드를 true로 변경합니다.

## 🔁 변경 사항
 `200 OK`

```json
{
	"isSuccess": true,
	"code" : 200,
	"message" : "요청이 성공적으로 처리되었습니다."
}
```

`400 Bad Request`
(이미 approved가 true일 때)

```json
{
    "isSuccess": false,
    "code": "PROFILE409",
    "message": "이미 저장된 프로필입니다."
}
```

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
