### PR TITLE
#112 마이페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/example/aboutme/app/controller/MyPageController.java
+++ b/src/main/java/com/example/aboutme/app/controller/MyPageController.java
@@ -18,6 +18,11 @@ public class MyPageController {
 
     private final MemberService memberService;
 
+    /**
+     * [GET] /mypages
+     * @param memberId 멤버 식별자
+     * @return
+     */
     @GetMapping("")
     public ApiResponse<MyPageResponse.GetMyPageDTO> getMyPage(@RequestHeader("member-id") Long memberId){
 

--- a/src/main/java/com/example/aboutme/app/controller/MyPageController.java
+++ b/src/main/java/com/example/aboutme/app/controller/MyPageController.java
@@ -1,0 +1,30 @@
+package com.example.aboutme.app.controller;
+
+import com.example.aboutme.apiPayload.ApiResponse;
+import com.example.aboutme.app.dto.MyPageResponse;
+import com.example.aboutme.service.MemberService.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mypages")
+@RequiredArgsConstructor
+@Slf4j
+public class MyPageController {
+
+    private final MemberService memberService;
+
+    @GetMapping("")
+    public ApiResponse<MyPageResponse.GetMyPageDTO> getMyPage(@RequestHeader("member-id") Long memberId){
+
+        MyPageResponse.GetMyPageDTO getMyPageDTO = memberService.getMyPage(memberId);
+
+        log.info("마이페이지 조회: {}", memberId);
+
+        return ApiResponse.onSuccess(getMyPageDTO);
+    }
+}

--- a/src/main/java/com/example/aboutme/app/dto/MyPageResponse.java
+++ b/src/main/java/com/example/aboutme/app/dto/MyPageResponse.java
@@ -1,0 +1,46 @@
+package com.example.aboutme.app.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MyPageResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMyPageDTO {
+        @JsonProperty("my_info")
+        private MyPageInfo myPageInfo;
+
+        @JsonProperty("insight")
+        private MyPageInsight myPageInsight;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyPageInfo{
+        @JsonProperty("profile_name")
+        private String profileName;
+
+        @JsonProperty("space_name")
+        private String spaceName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyPageInsight{
+        @JsonProperty("profile_shared_num")
+        private int profileSharedNum;
+
+        @JsonProperty("space_shared_num")
+        private int spaceSharedNum;
+    }
+}

--- a/src/main/java/com/example/aboutme/converter/MemberConverter.java
+++ b/src/main/java/com/example/aboutme/converter/MemberConverter.java
@@ -1,5 +1,6 @@
 package com.example.aboutme.converter;
 
+import com.example.aboutme.app.dto.MyPageResponse;
 import com.example.aboutme.app.dto.SocialInfoRequest;
 import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.constant.Social;
@@ -16,4 +17,20 @@ public class MemberConverter {
                 .jwtAccessToken(token).build();
     }
 
+    public static MyPageResponse.GetMyPageDTO toGetMyPageDTO (String profileName, String spaceName, int profileSharedNum, int spaceSharedNum){
+        MyPageResponse.MyPageInfo myPageInfo = MyPageResponse.MyPageInfo.builder()
+                .profileName(profileName)
+                .spaceName(spaceName)
+                .build();
+
+        MyPageResponse.MyPageInsight myPageInsight = MyPageResponse.MyPageInsight.builder()
+                .profileSharedNum(profileSharedNum)
+                .spaceSharedNum(spaceSharedNum)
+                .build();
+
+        return MyPageResponse.GetMyPageDTO.builder()
+                .myPageInfo(myPageInfo)
+                .myPageInsight(myPageInsight)
+                .build();
+    }
 }

--- a/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
@@ -4,6 +4,8 @@ import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.Profile;
 import com.example.aboutme.domain.mapping.MemberProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,4 +17,9 @@ public interface MemberProfileRepository extends JpaRepository<MemberProfile, Lo
     MemberProfile findByMemberAndProfile(Member member, Profile profile);
     Boolean existsByMemberAndProfile(Member member, Profile profile);
     List<MemberProfile> findByMemberAndProfileIn(Member member, List<Profile> profiles);
+
+    @Query("select count(*)" +
+            "from MemberProfile mp join Profile as p on mp.profile = p " +
+            "where p.member = :member")
+    Integer countSharedProfileByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
@@ -18,6 +18,11 @@ public interface MemberProfileRepository extends JpaRepository<MemberProfile, Lo
     Boolean existsByMemberAndProfile(Member member, Profile profile);
     List<MemberProfile> findByMemberAndProfileIn(Member member, List<Profile> profiles);
 
+    /**
+     * 내 마이프로필 공유 현황 (내 마이프로필이 상대방의 보관함에 얼마나 저장되었는지)
+     * @param member 조회하려는 멤버
+     * @return 공유된 마이프로필 개수
+     */
     @Query("select count(*)" +
             "from MemberProfile mp join Profile as p on mp.profile = p " +
             "where p.member = :member")

--- a/src/main/java/com/example/aboutme/repository/MemberRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.example.aboutme.repository;
 
+import com.example.aboutme.app.dto.MyPageResponse;
 import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.constant.Social;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByEmailAndSocial(String email, Social social);

--- a/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
@@ -5,6 +5,8 @@ import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.Space;
 import com.example.aboutme.domain.mapping.MemberSpace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +15,8 @@ public interface MemberSpaceRepository extends JpaRepository<MemberSpace, Long> 
 
     List<MemberSpace> findByMemberAndSpace_NicknameContaining(Member member, String keyword);
 
+    @Query("select count(*)" +
+            "from MemberSpace ms join Space s on ms.space = s " +
+            "where s.member = :member")
+    Integer countSharedProfileByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
@@ -23,5 +23,5 @@ public interface MemberSpaceRepository extends JpaRepository<MemberSpace, Long> 
     @Query("select count(*)" +
             "from MemberSpace ms join Space s on ms.space = s " +
             "where s.member = :member")
-    Integer countSharedProfileByMember(@Param("member") Member member);
+    Integer countSharedSpaceByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberSpaceRepository.java
@@ -15,6 +15,11 @@ public interface MemberSpaceRepository extends JpaRepository<MemberSpace, Long> 
 
     List<MemberSpace> findByMemberAndSpace_NicknameContaining(Member member, String keyword);
 
+    /**
+     * 내 마이스페이스 공유 현황 (내 마이스페이스가 상대방의 보관함에 얼마나 저장되었는지)
+     * @param member 조회하려는 멤버
+     * @return 공유된 마이스페이스 개수
+     */
     @Query("select count(*)" +
             "from MemberSpace ms join Space s on ms.space = s " +
             "where s.member = :member")

--- a/src/main/java/com/example/aboutme/repository/ProfileFeatureRepository.java
+++ b/src/main/java/com/example/aboutme/repository/ProfileFeatureRepository.java
@@ -1,10 +1,21 @@
 package com.example.aboutme.repository;
 
+import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.ProfileFeature;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ProfileFeatureRepository extends JpaRepository<ProfileFeature, Long> {
     List<ProfileFeature> findByProfileKeyAndProfileValueContaining(String profileKey, String profileValue);
+
+    @Query("select pf.profileValue " +
+            "from Profile p " +
+            "join ProfileFeature pf on p = pf.profile " +
+            "where pf.profileKey = 'name' and p.member = :member " +
+            "order by p.isDefault desc, p.createdAt asc ")
+    List<String> findProfileFeature(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/aboutme/repository/ProfileRepository.java
+++ b/src/main/java/com/example/aboutme/repository/ProfileRepository.java
@@ -2,7 +2,10 @@ package com.example.aboutme.repository;
 
 import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.Profile;
+import com.example.aboutme.domain.ProfileFeature;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import java.util.List;

--- a/src/main/java/com/example/aboutme/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/aboutme/service/MemberService/MemberService.java
@@ -10,5 +10,10 @@ public interface MemberService {
     Member findMember(Long memberId);
     void deleteMember(Long memberId);
 
+    /**
+     * 마이페이지 조회
+     * @param memberId 멤버 식별자
+     * @return 마이프로필 정보
+     */
     MyPageResponse.GetMyPageDTO getMyPage(Long memberId);
 }

--- a/src/main/java/com/example/aboutme/service/MemberService/MemberService.java
+++ b/src/main/java/com/example/aboutme/service/MemberService/MemberService.java
@@ -1,5 +1,6 @@
 package com.example.aboutme.service.MemberService;
 
+import com.example.aboutme.app.dto.MyPageResponse;
 import com.example.aboutme.domain.Member;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +10,5 @@ public interface MemberService {
     Member findMember(Long memberId);
     void deleteMember(Long memberId);
 
+    MyPageResponse.GetMyPageDTO getMyPage(Long memberId);
 }

--- a/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
@@ -45,7 +45,7 @@ public class MemberServiceImpl implements MemberService{
         String spaceName = member.getSpace() != null ? member.getSpace().getNickname() : null;
 
         int profileSharedNum = memberProfileRepository.countSharedProfileByMember(member);
-        int spaceSharedNum = memberSpaceRepository.countSharedProfileByMember(member);
+        int spaceSharedNum = memberSpaceRepository.countSharedSpaceByMember(member);
 
         return MemberConverter.toGetMyPageDTO(profileName, spaceName, profileSharedNum, spaceSharedNum);
     }

--- a/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
@@ -33,6 +33,11 @@ public class MemberServiceImpl implements MemberService{
         memberRepository.deleteById(memberId);
     }
 
+    /**
+     * 마이페이지 조회
+     * @param memberId 멤버 식별자
+     * @return 마이프로필 정보
+     */
     public MyPageResponse.GetMyPageDTO getMyPage(Long memberId){
         Member member = findMember(memberId);
 

--- a/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberService/MemberServiceImpl.java
@@ -2,9 +2,12 @@ package com.example.aboutme.service.MemberService;
 
 import com.example.aboutme.apiPayload.code.status.ErrorStatus;
 import com.example.aboutme.apiPayload.exception.GeneralException;
+import com.example.aboutme.app.dto.MyPageResponse;
+import com.example.aboutme.converter.MemberConverter;
 import com.example.aboutme.domain.Member;
-import com.example.aboutme.repository.MemberRepository;
+import com.example.aboutme.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService{
 
     private final MemberRepository memberRepository;
+    private final ProfileFeatureRepository profileFeatureRepository;
+    private final MemberProfileRepository memberProfileRepository;
+    private final MemberSpaceRepository memberSpaceRepository;
 
     public Member findMember(Long memberId){
         return memberRepository.findById(memberId).orElseThrow(
@@ -25,5 +31,17 @@ public class MemberServiceImpl implements MemberService{
     public void deleteMember(Long memberId){
         findMember(memberId);
         memberRepository.deleteById(memberId);
+    }
+
+    public MyPageResponse.GetMyPageDTO getMyPage(Long memberId){
+        Member member = findMember(memberId);
+
+        String profileName = profileFeatureRepository.findProfileFeature(member, PageRequest.of(0,1)).get(0);
+        String spaceName = member.getSpace() != null ? member.getSpace().getNickname() : null;
+
+        int profileSharedNum = memberProfileRepository.countSharedProfileByMember(member);
+        int spaceSharedNum = memberSpaceRepository.countSharedProfileByMember(member);
+
+        return MemberConverter.toGetMyPageDTO(profileName, spaceName, profileSharedNum, spaceSharedNum);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #112 

## 📌 개요
- 마이페이지 조회 API 구현

## 🔁 변경 사항
- 정상 응답
```
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "my_info": {
            "profile_name": "김테스트",
            "space_name": "테스트의 스페이스"
        },
        "insight": {
            "profile_shared_num": 2,
            "space_shared_num": 0
        }
    }
}
```
- 오류 응답
```
{
    "isSuccess": false,
    "code": "MEMBER400",
    "message": "해당하는 사용자가 존재하지 않습니다"
}
```

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- sql문을 한번에 짤수있으면 그렇게 하는게 더 좋을지 고민이 됩니다.
- query문을 날리지 않고 객체조회로 끝낼 수 있는 방법이 있다면 알려주시면 감사하겠습니다!

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
