### PR TITLE
#118 마이프로필 공유 → 알람 데이터 생성

### DIFF
--- a/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
@@ -57,7 +57,10 @@ public enum ErrorStatus implements BaseErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE400", "해당 파일이 존재하지 않습니다."),
 
     // 소셜타입 에러
-    UNKNOWN_SOCIALTYPE(HttpStatus.NOT_FOUND, "SOCIAL400", "해당 소셜 타입이 존재하지 않습니다.");
+    UNKNOWN_SOCIALTYPE(HttpStatus.NOT_FOUND, "SOCIAL400", "해당 소셜 타입이 존재하지 않습니다."),
+
+    // 알람 에러
+    ALARM_ALREADY_EXISTING(HttpStatus.BAD_REQUEST, "ALARM400", "해당 알람이 이미 존재합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_NOT_MATCH_MEMBER_AT_GET(HttpStatus.BAD_REQUEST, "PROFILE406", "해당 프로필을 조회할 수 없습니다"),
     PROFILE_NOT_MATCH_MEMBER_AT_UPDATE(HttpStatus.BAD_REQUEST, "PROFILE407", "해당 프로필을 수정할 수 없습니다"),
     PROFILE_NOT_MINE(HttpStatus.BAD_REQUEST, "PROFILE408", "공유하려는 프로필이 본인 것이 아닙니다."),
+    PROFILE_ALREADY_SHARED(HttpStatus.BAD_REQUEST, "PROFILE409", "이미 저장된 프로필입니다."),
 
     // 마이프로필 이미지 에러
     PROFILE_IMAGE_CANNOT_CHANGE_TO_CHARACTER(HttpStatus.BAD_REQUEST, "IMAGE400", "마이스페이스에서 캐릭터를 설정해야 합니다"),

--- a/src/main/java/com/example/aboutme/app/controller/MemberProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/MemberProfileController.java
@@ -12,6 +12,7 @@ import com.example.aboutme.domain.mapping.MemberSpace;
 import com.example.aboutme.service.MemberProfileService.MemberProfileService;
 import com.example.aboutme.validation.annotation.ExistMyProfile;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +24,7 @@ import java.util.List;
 @RequestMapping("/myprofiles/storage")
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 public class MemberProfileController {
 
     private final MemberProfileService memberProfileService;
@@ -51,6 +53,8 @@ public class MemberProfileController {
     public ApiResponse<MemberProfileResponse.SearchMemberProfileListDTO> searchMemberProfileList(@RequestHeader("member-id") Long memberId,
                                                                                            @RequestParam(defaultValue = "") String keyword) {
         List<MemberProfile> memberProfileList = memberProfileService.filterWithKeyword(memberId, keyword);
+        log.info("프로필 보관함 내 검색하기: member={}, keyword={}", memberId, keyword);
+
         return ApiResponse.onSuccess(MemberProfileConverter.toSearchMemberProfileListDTO(memberProfileList));
     }
 

--- a/src/main/java/com/example/aboutme/app/controller/ProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/ProfileController.java
@@ -195,7 +195,7 @@ public class ProfileController {
 
         memberProfileService.sendMyProfile(memberId, request);
 
-        log.info("상대방 마이프로필 내 보관함에 추가하기: member={}, other's profile={}, my profile={}", memberId, request.getTargetProfileSerialNumberList(), request.getMyProfileSerialNumberList());
+        log.info("마이프로필 공유 → 알림 데이터 생성: member={}, other's profile={}, my profile={}", memberId, request.getOthersProfileSerialNumberList(), request.getMyProfileSerialNumberList());
 
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/example/aboutme/app/controller/ProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/ProfileController.java
@@ -215,4 +215,21 @@ public class ProfileController {
 
         return ApiResponse.onSuccess(ProfileConverter.toSearchProfile(profile));
     }
+
+    /**
+     * [PATCH] /myprofiles/share/approve
+     * 프로필 공유받기
+     *
+     * @param memberId 멤버 식별자
+     * @param profileId 마이프로필 식별자
+     * @return
+     */
+    @PatchMapping("/share/{profile-id}")
+    public ApiResponse<Void> approveProfile(@RequestHeader("member-id") Long memberId,
+                                            @PathVariable("profile-id") @ExistMyProfile Long profileId) {
+
+        memberProfileService.toggleApproved(memberId, profileId);
+
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/com/example/aboutme/app/controller/ProfileController.java
+++ b/src/main/java/com/example/aboutme/app/controller/ProfileController.java
@@ -171,31 +171,31 @@ public class ProfileController {
      * @return
      */
     @PostMapping("/share")
-    public ApiResponse<ProfileResponse.ShareProfileDTO> shareProfile(@RequestHeader("member-id") Long memberId,
+    public ApiResponse<Void> shareProfile(@RequestHeader("member-id") Long memberId,
                                                                      @RequestBody @Valid ProfileRequest.ShareProfileDTO request) {
 
-        Long profileOwnerId = memberProfileService.addOthersProfilesAtMyStorage(memberId, request);
+        memberProfileService.addOthersProfilesAtMyStorage(memberId, request);
 
         log.info("상대방 마이프로필 내 보관함에 추가하기: member={}, other's profile={}", memberId, request.getProfileSerialNumberList());
 
-        return ApiResponse.onSuccess(ProfileConverter.toShareMyProfileDTO(profileOwnerId));
+        return ApiResponse.onSuccess(null);
     }
 
     /**
-     * [POST] /myprofiles/share/mine
-     * 내 마이프로필 상대방에게 공유하기
+     * [POST] /myprofiles/send
+     * 마이프로필 공유 → 알림 데이터 생성
      *
      * @param memberId 멤버 식별자
      * @param request
      * @return
      */
-    @PostMapping("/share/mine")
-    public ApiResponse<Void> shareProfile(@RequestHeader("member-id") Long memberId,
-                                          @RequestBody @Valid ProfileRequest.ShareMyProfileDTO request) {
+    @PostMapping("/send")
+    public ApiResponse<Void> sendProfile(@RequestHeader("member-id") Long memberId,
+                                          @RequestBody @Valid ProfileRequest.SendProfileDTO request) {
 
-        memberProfileService.shareMyProfilesToOthers(memberId, request);
+        memberProfileService.sendMyProfile(memberId, request);
 
-        log.info("상대방 마이프로필 내 보관함에 추가하기: member={}, other's profile={}", memberId, request.getProfileSerialNumberList());
+        log.info("상대방 마이프로필 내 보관함에 추가하기: member={}, other's profile={}, my profile={}", memberId, request.getTargetProfileSerialNumberList(), request.getMyProfileSerialNumberList());
 
         return ApiResponse.onSuccess(null);
     }
@@ -214,22 +214,5 @@ public class ProfileController {
         log.info("마이프로필 검색하기: {}", serialNumber);
 
         return ApiResponse.onSuccess(ProfileConverter.toSearchProfile(profile));
-    }
-
-    /**
-     * [PATCH] /myprofiles/share/approve
-     * 프로필 공유받기
-     *
-     * @param memberId 멤버 식별자
-     * @param profileId 마이프로필 식별자
-     * @return
-     */
-    @PatchMapping("/share/{profile-id}")
-    public ApiResponse<Void> approveProfile(@RequestHeader("member-id") Long memberId,
-                                            @PathVariable("profile-id") @ExistMyProfile Long profileId) {
-
-        memberProfileService.toggleApproved(memberId, profileId);
-
-        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
@@ -48,8 +48,8 @@ public class ProfileRequest {
     @Getter
     public static class ShareMyProfileDTO{
 
-        @JsonProperty("member_id")
-        private Long memberId;
+        @JsonProperty("target_member_id")
+        private Long targetMemberId;
 
         @JsonProperty("profile_serial_numbers")
         @ExistProfilesBySerialNum

--- a/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
@@ -46,13 +46,13 @@ public class ProfileRequest {
     }
 
     @Getter
-    public static class ShareMyProfileDTO{
-
-        @JsonProperty("target_member_id")
-        private Long targetMemberId;
-
-        @JsonProperty("profile_serial_numbers")
+    public static class SendProfileDTO{
+        @JsonProperty("target_profile_serial_numbers")
         @ExistProfilesBySerialNum
-        private List<Integer> profileSerialNumberList;
+        private List<Integer> TargetProfileSerialNumberList;
+
+        @JsonProperty("my_profile_serial_numbers")
+        @ExistProfilesBySerialNum
+        private List<Integer> MyProfileSerialNumberList;
     }
 }

--- a/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
+++ b/src/main/java/com/example/aboutme/app/dto/ProfileRequest.java
@@ -47,9 +47,9 @@ public class ProfileRequest {
 
     @Getter
     public static class SendProfileDTO{
-        @JsonProperty("target_profile_serial_numbers")
+        @JsonProperty("others_profile_serial_numbers")
         @ExistProfilesBySerialNum
-        private List<Integer> TargetProfileSerialNumberList;
+        private List<Integer> OthersProfileSerialNumberList;
 
         @JsonProperty("my_profile_serial_numbers")
         @ExistProfilesBySerialNum

--- a/src/main/java/com/example/aboutme/converter/AlarmConverter.java
+++ b/src/main/java/com/example/aboutme/converter/AlarmConverter.java
@@ -1,0 +1,17 @@
+package com.example.aboutme.converter;
+
+import com.example.aboutme.domain.Alarm;
+import com.example.aboutme.domain.Member;
+import com.example.aboutme.domain.Profile;
+
+
+public class AlarmConverter {
+    public static Alarm toProfileAlarm(Member member, Profile profile, String profileName){
+        return Alarm.builder()
+                .content(String.format("%s님이 프로필을 공유하셨습니다", profileName))
+                .isRead(false)
+                .member(member)
+                .profile(profile)
+                .build();
+    }
+}

--- a/src/main/java/com/example/aboutme/converter/MemberProfileConverter.java
+++ b/src/main/java/com/example/aboutme/converter/MemberProfileConverter.java
@@ -46,16 +46,6 @@ public class MemberProfileConverter {
                 .favorite(false)
                 .member(member)
                 .profile(profile)
-                .approved(true)
-                .build();
-    }
-
-    public static MemberProfile toMemberProfileNotApproved(Member member, Profile profile){
-        return MemberProfile.builder()
-                .favorite(false)
-                .member(member)
-                .profile(profile)
-                .approved(false)
                 .build();
     }
 

--- a/src/main/java/com/example/aboutme/converter/ProfileConverter.java
+++ b/src/main/java/com/example/aboutme/converter/ProfileConverter.java
@@ -126,13 +126,6 @@ public class ProfileConverter {
                 .build();
     }
 
-
-    public static ProfileResponse.ShareProfileDTO toShareMyProfileDTO(Long memberId) {
-        return ProfileResponse.ShareProfileDTO.builder()
-                .memberId(memberId)
-                .build();
-    }
-
     public static ProfileResponse.SearchProfileDTO toSearchProfile(Profile profile){
         return ProfileResponse.SearchProfileDTO.builder()
                 .profileId(profile.getId())

--- a/src/main/java/com/example/aboutme/domain/Alarm.java
+++ b/src/main/java/com/example/aboutme/domain/Alarm.java
@@ -3,10 +3,7 @@ package com.example.aboutme.domain;
 import com.example.aboutme.domain.common.BaseEntity;
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @AllArgsConstructor
@@ -19,5 +16,14 @@ public class Alarm extends BaseEntity {
     private Long id;
 
     private String content;
+
     private boolean isRead;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
 }

--- a/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
+++ b/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
@@ -20,8 +20,6 @@ public class MemberProfile extends BaseEntity {
 
     private Boolean favorite;
 
-    private Boolean approved;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -32,9 +30,5 @@ public class MemberProfile extends BaseEntity {
 
     public void toggleFavorite() {
         this.favorite = !this.favorite;
-    }
-
-    public void toggleApproved() {
-        this.approved = !this.approved;
     }
 }

--- a/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
+++ b/src/main/java/com/example/aboutme/domain/mapping/MemberProfile.java
@@ -30,8 +30,11 @@ public class MemberProfile extends BaseEntity {
     @JoinColumn(name = "profile_id")
     private Profile profile;
 
-    // 즐겨찾기 토글 메서드
     public void toggleFavorite() {
         this.favorite = !this.favorite;
+    }
+
+    public void toggleApproved() {
+        this.approved = !this.approved;
     }
 }

--- a/src/main/java/com/example/aboutme/repository/AlarmRepository.java
+++ b/src/main/java/com/example/aboutme/repository/AlarmRepository.java
@@ -1,0 +1,12 @@
+package com.example.aboutme.repository;
+
+import com.example.aboutme.domain.Alarm;
+import com.example.aboutme.domain.Member;
+import com.example.aboutme.domain.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+    Boolean existsByMemberAndProfile(Member member, Profile profile);
+
+}

--- a/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
+++ b/src/main/java/com/example/aboutme/repository/MemberProfileRepository.java
@@ -10,12 +10,12 @@ import java.util.List;
 public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
 //    List<MemberProfile> findAllByMember(Member member);
 
-    List<MemberProfile> findAllByMemberAndApprovedIsTrue(Member member);
+    List<MemberProfile> findAllByMember(Member member);
 
 
 //    MemberProfile findByMemberAndId(Member member, Long memberProfileId);
 
     MemberProfile findByMemberAndProfile(Member member, Profile profile);
     Boolean existsByMemberAndProfile(Member member, Profile profile);
-    List<MemberProfile> findByMemberAndProfileInAndApprovedIsTrue(Member member, List<Profile> profileList);
+    List<MemberProfile> findByMemberAndProfileIn(Member member, List<Profile> profileList);
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
@@ -11,6 +11,8 @@ import java.util.List;
 public interface MemberProfileService {
     Boolean toggleFavorite(Long memberId, Long profileId);
 
+    Boolean toggleApproved(Long memberId, Long profileId);
+
     List<MemberProfile> getMyProfilesStorage(Long memberId);
 
     MemberProfile deleteMemberProfile(Long memberId, Long profileId);

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileService.java
@@ -11,8 +11,6 @@ import java.util.List;
 public interface MemberProfileService {
     Boolean toggleFavorite(Long memberId, Long profileId);
 
-    Boolean toggleApproved(Long memberId, Long profileId);
-
     List<MemberProfile> getMyProfilesStorage(Long memberId);
 
     MemberProfile deleteMemberProfile(Long memberId, Long profileId);
@@ -21,9 +19,9 @@ public interface MemberProfileService {
      * @param memberId 멤버 식별자
      * @param request
      */
-    Long addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request);
+    void addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request);
 
-    void shareMyProfilesToOthers(Long memberId, ProfileRequest.ShareMyProfileDTO request);
+    void sendMyProfile(Long memberId, ProfileRequest.SendProfileDTO request);
 
     List<MemberProfile> filterWithKeyword(Long memberId, String keyword);
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -162,4 +162,31 @@ public class MemberProfileServiceImpl implements MemberProfileService {
             memberProfileRepository.save(memberProfile);
         });
     }
+
+
+    /**
+     * 프로필 공유받기
+     * @param memberId 멤버 식별자
+     * @param profileId 마이프로필 식별자
+     */
+    @Transactional
+    public Boolean toggleApproved(Long memberId, Long profileId) {
+
+        Member member = memberService.findMember(memberId);
+
+        Profile profile = profileRepository.findById(profileId).get();
+
+        MemberProfile memberProfile = memberProfileRepository.findByMemberAndProfile(member, profile);
+        if (memberProfile == null) {
+            throw new GeneralException(ErrorStatus.MEMBER_PROFILE_NOT_FOUND);
+        }
+
+        if (memberProfile.getApproved()) {
+            throw new GeneralException(ErrorStatus.PROFILE_ALREADY_SHARED);
+        }
+
+        memberProfile.toggleApproved();
+
+        return memberProfile.getApproved();
+    }
 }

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -141,7 +141,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
                 .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
                 .toList();
 
-        Member shareTarget = memberService.findMember(request.getMemberId());
+        Member shareTarget = memberService.findMember(request.getTargetMemberId());
 
         for(Profile otherProfile : otherProfileList){
             // 공유하려는 프로필이 본인게 아닌 경우

--- a/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/MemberProfileService/MemberProfileServiceImpl.java
@@ -3,15 +3,14 @@ package com.example.aboutme.service.MemberProfileService;
 import com.example.aboutme.apiPayload.code.status.ErrorStatus;
 import com.example.aboutme.apiPayload.exception.GeneralException;
 import com.example.aboutme.app.dto.ProfileRequest;
+import com.example.aboutme.converter.AlarmConverter;
 import com.example.aboutme.converter.MemberProfileConverter;
+import com.example.aboutme.domain.Alarm;
 import com.example.aboutme.domain.Member;
 import com.example.aboutme.domain.Profile;
 import com.example.aboutme.domain.ProfileFeature;
 import com.example.aboutme.domain.mapping.MemberProfile;
-import com.example.aboutme.repository.MemberProfileRepository;
-import com.example.aboutme.repository.MemberRepository;
-import com.example.aboutme.repository.ProfileFeatureRepository;
-import com.example.aboutme.repository.ProfileRepository;
+import com.example.aboutme.repository.*;
 import com.example.aboutme.service.MemberService.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +29,7 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     private final ProfileRepository profileRepository;
     private final ProfileFeatureRepository profileFeatureRepository;
     private final MemberService memberService;
+    private final AlarmRepository alarmRepository;
 
     // 프로필 보관함 즐겨찾기
     @Transactional
@@ -50,16 +50,16 @@ public class MemberProfileServiceImpl implements MemberProfileService {
         return memberProfile.getFavorite();
     }
 
-    public List<MemberProfile> getMyProfilesStorage(Long memberId){
+    public List<MemberProfile> getMyProfilesStorage(Long memberId) {
         Member member = memberService.findMember(memberId);
         return memberProfileRepository.findAllByMember(member);
     }
 
     @Transactional
-    public MemberProfile deleteMemberProfile(Long memberId, Long profileId){
+    public MemberProfile deleteMemberProfile(Long memberId, Long profileId) {
         Member member = memberService.findMember(memberId);
         Profile profile = profileRepository.findById(profileId)
-                .orElseThrow(()->new GeneralException(ErrorStatus.PROFILE_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PROFILE_NOT_FOUND));
 //        boolean isSame = profile.getMember().getId().equals(memberId);
 //        if (!isSame){
 //            throw new GeneralException(ErrorStatus.MEMBER_IS_NOT_PROFILE_CREATOR);
@@ -71,11 +71,12 @@ public class MemberProfileServiceImpl implements MemberProfileService {
 
     /**
      * 상대방 마이프로필 내 보관함에 추가하기
+     *
      * @param memberId 멤버 식별자
      * @param request
      */
     @Transactional
-    public void addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request){
+    public void addOthersProfilesAtMyStorage(Long memberId, ProfileRequest.ShareProfileDTO request) {
 
         Member member = memberService.findMember(memberId);
 
@@ -84,13 +85,13 @@ public class MemberProfileServiceImpl implements MemberProfileService {
                 .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
                 .toList();
 
-        for(Profile otherProfile : otherProfileList){
+        for (Profile otherProfile : otherProfileList) {
             // 이미 공유된 프로필일 경우
-            if(memberProfileRepository.existsByMemberAndProfile(member, otherProfile)){
+            if (memberProfileRepository.existsByMemberAndProfile(member, otherProfile)) {
                 throw new GeneralException(ErrorStatus.MEMBER_PROFILE_ALREADY_EXIST);
             }
             // 본인의 프로필을 추가하려는 경우
-            if(otherProfile.getMember() == member){
+            if (otherProfile.getMember() == member) {
                 throw new GeneralException(ErrorStatus.CANNOT_SHARE_OWN_PROFILE);
             }
         }
@@ -106,8 +107,9 @@ public class MemberProfileServiceImpl implements MemberProfileService {
 
     /**
      * 프로필 보관함 내 검색하기
+     *
      * @param memberId 멤버 식별자
-     * @param keyword 검색어(프로필 이름)
+     * @param keyword  검색어(프로필 이름)
      */
     public List<MemberProfile> filterWithKeyword(Long memberId, String keyword) {
 
@@ -124,7 +126,60 @@ public class MemberProfileServiceImpl implements MemberProfileService {
 
     /**
      * 마이프로필 공유 -> 알람데이터 생성
+     *
      * @param memberId 멤버 식별자
      * @param request
      */
+    @Transactional
+    public void sendMyProfile(Long memberId, ProfileRequest.SendProfileDTO request) {
+
+        Member member = memberService.findMember(memberId);
+
+        // 상대방 마이프로필 목록 조회
+        List<Profile> otherProfileList = request.getOthersProfileSerialNumberList().stream()
+                .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
+                .toList();
+
+        for (Profile otherProfile : otherProfileList) {
+            // 상대방 프로필 일련번호란에 본인 프로필 일련번호를 기입한 경우
+            if (otherProfile.getMember() == member) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST);
+            }
+        }
+
+        Member targetMember = otherProfileList.get(0).getMember();
+
+        // 공유할 마이프로필 목록 조회
+        List<Profile> myProfileList = request.getMyProfileSerialNumberList().stream()
+                .map(serialNum -> profileRepository.findBySerialNumber(serialNum).get())
+                .toList();
+
+        for (Profile myProfile : myProfileList) {
+            // 이미 공유된 프로필일 경우
+            if (memberProfileRepository.existsByMemberAndProfile(targetMember, myProfile)) {
+                throw new GeneralException(ErrorStatus.MEMBER_PROFILE_ALREADY_EXIST);
+            }
+            // 이미 생성된 알람인 경우
+            if (alarmRepository.existsByMemberAndProfile(targetMember, myProfile)) {
+                throw new GeneralException(ErrorStatus.ALARM_ALREADY_EXISTING);
+            }
+            // 본인의 프로필이 아닌 경우
+            if (myProfile.getMember() != member) {
+                throw new GeneralException(ErrorStatus.PROFILE_NOT_MINE);
+            }
+        }
+
+        List<Alarm> alarmList = myProfileList.stream()
+                .map(myProfile -> {
+                    String profileValue = myProfile.getProfileFeatureList().stream()
+                            .filter(profileFeature -> profileFeature.getProfileKey().equals("name"))
+                            .map(ProfileFeature::getProfileValue).findFirst().orElse(null);
+                    return AlarmConverter.toProfileAlarm(targetMember, myProfile, profileValue);
+                })
+                .toList();
+
+        alarmList.forEach(alarm -> {
+            alarmRepository.save(alarm);
+        });
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,9 +32,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://aboutmedb.cpk6suecg1c5.ap-northeast-2.rds.amazonaws.com/aboutme
+    url: jdbc:mysql://localhost:3306/aboutme
     username: root
-    password: rootroot123
+    password: jhoh5526
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,9 +32,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/aboutme
+    url: jdbc:mysql://aboutmedb.cpk6suecg1c5.ap-northeast-2.rds.amazonaws.com/aboutme
     username: root
-    password: jhoh5526
+    password: rootroot123
 
 cloud:
   aws:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #118 

## 📌 개요
- memberId가 아닌 프로필 일련번호로 상대방 유저 정보를 가져오도록 수정했습니다.
- MemberProfile에서 approved 칼럼 삭제했습니다.
- 공유시 프로필 알람 데이터 생성 
- 상대방이 알림창에서 저장 버튼 클릭시 '상대방 마이프로필 내 보관함에 추가하기' API를 사용하는 것을 염두로 두었습니다.<img width="479" alt="스크린샷 2024-02-15 오전 1 30 32" src="https://github.com/UMC-AboutMe/AboutMe-BE/assets/122276414/82decb06-dc53-46aa-abfd-646fb431bc05">


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
