### PR TITLE
#145 알림 데이터 삭제

### DIFF
--- a/src/main/java/com/example/aboutme/Login/jwt/TokenProvider.java
+++ b/src/main/java/com/example/aboutme/Login/jwt/TokenProvider.java
@@ -116,7 +116,7 @@ public class TokenProvider implements InitializingBean {
                 .parseClaimsJws(token)
                 .getBody();
 
-        if (claims.get("iss", String.class) == "GOOGLE"){
+        if (claims.get("iss", String.class).equals("GOOGLE")){
             return TokenDTO.tokenClaimsDTO.builder()
                     .email(claims.get("sub", String.class))
                     .social(Social.GOOGLE)

--- a/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/aboutme/apiPayload/code/status/ErrorStatus.java
@@ -60,7 +60,9 @@ public enum ErrorStatus implements BaseErrorCode {
     UNKNOWN_SOCIALTYPE(HttpStatus.NOT_FOUND, "SOCIAL400", "해당 소셜 타입이 존재하지 않습니다."),
 
     // 알람 에러
-    ALARM_ALREADY_EXISTING(HttpStatus.BAD_REQUEST, "ALARM400", "해당 알람이 이미 존재합니다.");
+    ALARM_ALREADY_EXISTING(HttpStatus.BAD_REQUEST, "ALARM400", "해당 알람이 이미 존재합니다."),
+    ALARM_NOT_MINE(HttpStatus.BAD_REQUEST, "ALARM401", "본인 알림이 아닙니다."),
+    ALARM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ALARM402", "해당 알림이 존재하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/aboutme/app/controller/AlarmController.java
+++ b/src/main/java/com/example/aboutme/app/controller/AlarmController.java
@@ -44,4 +44,23 @@ public class AlarmController {
 
         return ApiResponse.onSuccess(AlarmConverter.toGetAlarmListDTO(alarmList));
     }
+
+    /**
+     * [DELETE] /alarms
+     * 알람 데이터 삭제
+     * @param token 토큰
+     * @param alarmId 알림 식별자
+     * @return
+     */
+    @DeleteMapping("/{alarmId}")
+    public ApiResponse<Void> deleteProfileAlarm(@RequestHeader("token") String token, @PathVariable Long alarmId){
+
+        String email = tokenProvider.getTokenInfoFromToken(token).getEmail();
+        Social social = tokenProvider.getTokenInfoFromToken(token).getSocial();
+        Member member = memberService.findMember(email, social);
+
+        alarmService.deleteAlarm(member, alarmId);
+
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/com/example/aboutme/app/dto/AlarmResponse.java
+++ b/src/main/java/com/example/aboutme/app/dto/AlarmResponse.java
@@ -24,6 +24,8 @@ public class AlarmResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetAlarmDTO {
+        @JsonProperty("alarm_id")
+        private Long alarmId;
         @JsonProperty("content")
         private String content;
         @JsonProperty("profile_serial_number")

--- a/src/main/java/com/example/aboutme/converter/AlarmConverter.java
+++ b/src/main/java/com/example/aboutme/converter/AlarmConverter.java
@@ -38,6 +38,7 @@ public class AlarmConverter {
                     Space space = alarm.getSpace();
                     Long spaceId = space != null ? space.getId() : null;
                     return AlarmResponse.GetAlarmDTO.builder()
+                            .alarmId(alarm.getId())
                             .content(alarm.getContent())
                             .profileSerialNumber(profileSerialNumber)
                             .spaceId(spaceId)

--- a/src/main/java/com/example/aboutme/service/AlarmService/AlarmService.java
+++ b/src/main/java/com/example/aboutme/service/AlarmService/AlarmService.java
@@ -1,6 +1,7 @@
 package com.example.aboutme.service.AlarmService;
 import com.example.aboutme.app.dto.AlarmRequest;
 import com.example.aboutme.domain.Alarm;
+import com.example.aboutme.domain.Member;
 
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface AlarmService {
 
     Alarm shareSpace(Long memberId, AlarmRequest.CreateDTO request);
     List<Alarm> getAlarmList(Long memberId);
+
+    void deleteAlarm(Member member, Long alarmId);
 }

--- a/src/main/java/com/example/aboutme/service/AlarmService/AlarmServiceImpl.java
+++ b/src/main/java/com/example/aboutme/service/AlarmService/AlarmServiceImpl.java
@@ -1,4 +1,6 @@
 package com.example.aboutme.service.AlarmService;
+import com.example.aboutme.apiPayload.code.status.ErrorStatus;
+import com.example.aboutme.apiPayload.exception.GeneralException;
 import com.example.aboutme.app.dto.AlarmRequest;
 import com.example.aboutme.converter.AlarmConverter;
 import com.example.aboutme.domain.Alarm;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -46,5 +49,26 @@ public class AlarmServiceImpl implements AlarmService{
         Member member = memberService.findMember(memberId);
 
         return alarmRepository.findByMember(member);
+    }
+
+    /**
+     * 프로필 알람 데이터 삭제
+     * @param member 멤버
+     * @param alarmId 알림 식별자
+     */
+    @Transactional
+    public void deleteAlarm(Member member, Long alarmId) {
+
+        Alarm alarm = alarmRepository.findById(alarmId).orElseThrow(
+                () -> new GeneralException(ErrorStatus.ALARM_NOT_FOUND)
+        );
+
+        if (!alarm.getMember().equals(member)) {
+            throw new GeneralException(ErrorStatus.ALARM_NOT_MINE);
+        }
+
+        log.info("프로필 알람 데이터 삭제: alarmId={}", alarmId);
+
+        alarmRepository.delete(alarm);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #145 

## 📌 개요
- 알림 데이터 조회 API 응답 본문에 alarmId 추가했습니다.
- alarmId를 path variable로 받아 해당 알림 데이터를 삭제합니다.

`200 OK`

```json
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다."
}
```
`400 Bad Request`

```json
{
    "isSuccess": false,
    "code": "ALARM402",
    "message": "해당 알림이 존재하지 않습니다."
}
```
`400 Bad Request`

```json
{
    "isSuccess": false,
    "code": "ALARM401",
    "message": "본인 알림이 아닙니다."
}
```

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
